### PR TITLE
Add direct IP Printing

### DIFF
--- a/OpenLabel/Printing/NetworkPrinter.cs
+++ b/OpenLabel/Printing/NetworkPrinter.cs
@@ -16,12 +16,13 @@ namespace OpenLabel.Printing
         /// <param name="printerPath">The UNC path or hostname of the printer.</param>
         /// <param name="labelCount">The number of labels to print.</param>
         /// <param name="zplString">The ZPL code to send to the printer.</param>
+        /// <param name="ipAddress">The IP address of the printer. If not provided, the printer's hostname will be resolved.</param>'
         /// <returns>
         /// A <see cref="Result{T, E}"/> where:
         /// - <c>Ok(true)</c> indicates successful printing.
         /// - <c>Err(string)</c> contains an error message if printing fails.
         /// </returns>
-        public async Task<Result<bool, string>> PrintLabelAsync(string printerPath, int labelCount, string zplString, string ipAddress)
+        public async Task<Result<bool, string>> PrintLabelAsync(string printerPath, int labelCount, string zplString, string? ipAddress = null)
         {
             Result<string, string> ipResult;
             if (string.IsNullOrEmpty(printerPath))

--- a/OpenLabel/Printing/NetworkPrinter.cs
+++ b/OpenLabel/Printing/NetworkPrinter.cs
@@ -21,13 +21,30 @@ namespace OpenLabel.Printing
         /// - <c>Ok(true)</c> indicates successful printing.
         /// - <c>Err(string)</c> contains an error message if printing fails.
         /// </returns>
-        public async Task<Result<bool, string>> PrintLabelAsync(string printerPath, int labelCount, string zplString)
+        public async Task<Result<bool, string>> PrintLabelAsync(string printerPath, int labelCount, string zplString, string ipAddress)
         {
-            var ipResult = GetPrinterIpAddress(printerPath);
-            if (ipResult.IsFailure)
+            Result<string, string> ipResult;
+            if (string.IsNullOrEmpty(printerPath))
             {
-                return Result<bool, string>.Err(ipResult.Error);
+                var ipReach = IsPrinterReachable(ipAddress);
+                if (ipReach.IsFailure)
+                {
+                    return Result<bool, string>.Err($"Printer at IP address '{ipAddress}' is not reachable.");
+                }
+                else
+                {
+                    ipResult = Result<string, string>.Ok(ipAddress);
+                }
             }
+            else
+            {
+                ipResult = GetPrinterIpAddress(printerPath);
+                if (ipResult.IsFailure)
+                {
+                    return Result<bool, string>.Err(ipResult.Error);
+                }
+            }
+            
 
             using TcpClient client = new TcpClient();
             var connectTask = client.ConnectAsync(ipResult.Value, 9100);


### PR DESCRIPTION
Added an optional `ipAddress` parameter to `PrintLabelAsync`. 

Original API behavior is preserved. Passing anything other than an empty string or null to `printerPath` will cause the `printerPath` to be used for resolving the printer's IP address and the `ipAddress` parameter is effectively ignored.

If `printerPath` is null or empty, we check if the printer is reachable and set `ipResult` as required. If the printer is not reachable, we can simply return the result that it could not be reached.

Closes #2 